### PR TITLE
Update dump.js - Add fallback to current date

### DIFF
--- a/src/dump.js
+++ b/src/dump.js
@@ -20,8 +20,8 @@ const Dump = {
     return await Promise.all ( _.castArray ( xml['en-export'].note ).map ( async note => ({
       title: note.title,
       content: await Parse.content ( note.content, note.title ),
-      created: (note.created && Parse.date ( note.created )) || new Date(),
-      updated: (note.updated && Parse.date ( note.updated )) || new Date(),
+      created: ( note.created ) ? Parse.date ( note.created ) : new Date(),
+      updated: ( note.updated ) ? Parse.date ( note.updated ) : new Date(),
       tags: _.castArray ( note.tag || [] ),
       attachments: Config.dump.attachments && note.resource && _.castArray ( note.resource ).filter ( resource => resource.data ).map ( resource => ({
         buffer: Buffer.from ( resource.data, 'base64' ),

--- a/src/dump.js
+++ b/src/dump.js
@@ -20,8 +20,8 @@ const Dump = {
     return await Promise.all ( _.castArray ( xml['en-export'].note ).map ( async note => ({
       title: note.title,
       content: await Parse.content ( note.content, note.title ),
-      created: Parse.date ( note.created ),
-      updated: Parse.date ( note.updated ),
+      created: (note.created && Parse.date ( note.created )) || new Date(),
+      updated: (note.updated && Parse.date ( note.updated )) || new Date(),
       tags: _.castArray ( note.tag || [] ),
       attachments: Config.dump.attachments && note.resource && _.castArray ( note.resource ).filter ( resource => resource.data ).map ( resource => ({
         buffer: Buffer.from ( resource.data, 'base64' ),


### PR DESCRIPTION
Notes are sometimes missing created/updated dates in enex exported from Evernote. This mod allows parsing to fallback to current date in the case outlined above which would other wise cause a fatal failure with a 'Cannot read property split' message.