### PR TITLE
Include title and modified time in metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "chalk": "^2.4.1",
     "fast-xml-parser": "^3.12.10",
     "gray-matter": "^4.0.1",
+    "html-entities": "^1.2.1",
     "js-beautify": "^1.7.5",
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.10",

--- a/src/parse.js
+++ b/src/parse.js
@@ -2,6 +2,7 @@
 /* IMPORT */
 
 const {parse: xml2js} = require ( 'fast-xml-parser' ),
+      entities = require('html-entities').AllHtmlEntities,
       Config = require ( './config' ),
       Content = require ( './content' ),
       File = require ( './file' );
@@ -22,6 +23,12 @@ const Parse = {
     date = date.join ( '' );
 
     return new Date ( date );
+
+  },
+
+  title ( title ) {
+
+    return entities.decode( title );
 
   },
 


### PR DESCRIPTION
Other changes:
* Unescape HTML-encoded items like &amp;.
* If there is no modified time included, default to the created time.
This appears to be a common pattern in Evernote's exported data.

---

I like the look of Notable and am thinking of moving to it from Evernote. In fact, a while back I was trying to create a note app that had _very_ similar goals. Expect more PRs from me :)

First step is to get my data out of Evernote. This PR cleans up some missing pieces in the import into Notable.