### PR TITLE
Filename fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "caporal": "git://github.com/fabiospampinato/Caporal.js#optional-tabtab",
     "chalk": "^2.4.1",
     "fast-xml-parser": "^3.12.10",
+    "filenamify": "^2.1.0",
     "gray-matter": "^4.0.1",
     "html-entities": "^1.2.1",
     "js-beautify": "^1.7.5",

--- a/src/path.js
+++ b/src/path.js
@@ -2,9 +2,8 @@
 /* IMPORT */
 
 const path = require ( 'path' ),
+      filenamify = require ( 'filenamify' ),
       File = require ( './file' );
-
-const INVALID_FILENAME_CHARS = /[^\w\d_ .∕()-]/g;
 
 /* PATH */
 
@@ -29,10 +28,11 @@ const Path = {
   async getAllowedPath ( folderPath, baseName ) {
 
     baseName = baseName
-                  .replace ( /\//g, '∕' ) // Preserving a dash-like character
-                  .replace ( INVALID_FILENAME_CHARS, '-'); // Colons are reserved in some filesystems.
+                  .replace ( /\//g, '∕' ); // Preserving a dash-like character
 
-    const {name, ext} = path.parse ( baseName );
+    let {name, ext} = path.parse ( baseName );
+
+    name = Path.sanitize ( name );
 
     for ( let i = 1;; i++ ) {
 
@@ -48,6 +48,12 @@ const Path = {
 
     }
 
+  },
+
+  sanitize ( filePath ) {
+    return filenamify ( filePath, { replacement: ' ' } )
+             .replace ( /#/g, ' ' )
+             .trim ();
   }
 
 };

--- a/src/path.js
+++ b/src/path.js
@@ -4,6 +4,8 @@
 const path = require ( 'path' ),
       File = require ( './file' );
 
+const INVALID_FILENAME_CHARS = /[^\w\d_ .∕()-]/g;
+
 /* PATH */
 
 const Path = {
@@ -28,7 +30,7 @@ const Path = {
 
     baseName = baseName
                   .replace ( /\//g, '∕' ) // Preserving a dash-like character
-                  .replace ( ':', '.'); // Colons are reserved in some filesystems.
+                  .replace ( INVALID_FILENAME_CHARS, '-'); // Colons are reserved in some filesystems.
 
     const {name, ext} = path.parse ( baseName );
 

--- a/src/path.js
+++ b/src/path.js
@@ -26,7 +26,9 @@ const Path = {
 
   async getAllowedPath ( folderPath, baseName ) {
 
-    baseName = baseName.replace ( /\//g, '∕' ); // Preserving a dash-like character
+    baseName = baseName
+                  .replace ( /\//g, '∕' ) // Preserving a dash-like character
+                  .replace ( ':', '.'); // Colons are reserved in some filesystems.
 
     const {name, ext} = path.parse ( baseName );
 


### PR DESCRIPTION
Notes with colons in the title causes writing a note to disk to fail silently. This change replaces the colon with a period in the filename.

This resolves issue #5 